### PR TITLE
[임송이] Sprint 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# Google tag id
+env.js

--- a/faq/index.html
+++ b/faq/index.html
@@ -53,6 +53,7 @@
     />
 
     <!-- Google tag (gtag.js) -->
+    <script src="/env.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-WC2LGS3PNS"
@@ -64,7 +65,7 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-WC2LGS3PNS');
+      gtag('config', window.env.GA_TAG_ID);
     </script>
 
     <title>FAQ</title>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     />
     <meta name="author" content="임송이" />
 
+    <!-- mission 3 심화요구사항 open graph tags -->
+
     <!-- open graph  -->
     <!-- common meta tags-->
     <meta property="og:title" content="일상에서 모든 물건을 거래해보세요." />
@@ -53,6 +55,7 @@
     />
 
     <!-- Google tag (gtag.js) -->
+    <script src="/env.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-WC2LGS3PNS"
@@ -64,7 +67,7 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-WC2LGS3PNS');
+      gtag('config', window.env.GA_TAG_ID);
     </script>
 
     <title>판다마켓</title>

--- a/items/index.html
+++ b/items/index.html
@@ -53,6 +53,7 @@
     />
 
     <!-- Google tag (gtag.js) -->
+    <script src="/env.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-WC2LGS3PNS"
@@ -64,7 +65,7 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-WC2LGS3PNS');
+      gtag('config', window.env.GA_TAG_ID);
     </script>
 
     <title>판다마켓</title>

--- a/js/login.js
+++ b/js/login.js
@@ -1,3 +1,5 @@
+//mission 3
+
 import { eyeIconToggle } from './modules/eyeIcon.js';
 import { form, modal, modalBtn } from './modules/var.js';
 // import { USER_DATA } from './modules/userData.js';
@@ -32,7 +34,6 @@ form.querySelectorAll('input').forEach((input) => {
 });
 
 buttonStatus();
-
 
 form.addEventListener('submit', (e) => {
   e.preventDefault();

--- a/js/modules/eyeIcon.js
+++ b/js/modules/eyeIcon.js
@@ -1,3 +1,5 @@
+//mission 3
+
 //eye icon image toggle
 
 export function eyeIconToggle() {

--- a/js/modules/userData.js
+++ b/js/modules/userData.js
@@ -1,3 +1,5 @@
+//mission 3
+
 const USER_DATA = [
   { email: 'codeit1@codeit.com', password: 'codeit101!' },
   { email: 'codeit2@codeit.com', password: 'codeit202!' },

--- a/js/modules/validation.js
+++ b/js/modules/validation.js
@@ -1,3 +1,5 @@
+// mission 3
+
 import {
   emailInput,
   form,
@@ -54,6 +56,14 @@ function emptyInput(e) {
     return true;
   }
 }
+
+// 이벤트등록을 forEach로 하면서, function에서 e.target으로 인풋을 잡았는데요.
+// 저는 이게 코드를 덜 쓴다고 생각해서 했는데, 오히려 모든 functoin들이 이어지는?
+// 의존하는 것 같이 되는것 같아서..
+// 차라리 그냥 쿼리로 인풋 요소잡아서 하는게 더 효율적이였을까요?
+// 원래는 기능을 한번에 묶어서 validation 했어서 e.target으로 인풋 잡아도 괜찮았는데,
+// 나누니까 오히려 호출할때 꼭 e를 argument는 받아와야지만 기능하는 function들이 된거 같아서요.
+// (제가 어렴풋이만 아니까 설명이 잘안되네욤;;)
 
 //validate login format when value is not empty
 function logInFormat(e) {

--- a/js/modules/var.js
+++ b/js/modules/var.js
@@ -1,3 +1,5 @@
+//mission 3
+
 const form = document.querySelector('form');
 const emailField = form.querySelector('.email-field');
 const emailInput = emailField.querySelector('#user-email');

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,3 +1,5 @@
+//mission 3
+
 import { eyeIconToggle } from './modules/eyeIcon.js';
 import { form, modalBtn, modal, modalMsg } from './modules/var.js';
 // import { USER_DATA } from './modules/userData.js';

--- a/login/index.html
+++ b/login/index.html
@@ -53,6 +53,7 @@
     />
 
     <!-- Google tag (gtag.js) -->
+    <script src="/env.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-WC2LGS3PNS"
@@ -64,10 +65,11 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-WC2LGS3PNS');
+      gtag('config', window.env.GA_TAG_ID);
     </script>
 
     <title>로그인</title>
+
     <link rel="icon" href="/img/favicon.svg" />
     <link rel="stylesheet" href="/style/auth.css" />
     <link
@@ -129,6 +131,8 @@
       </div>
       <span>판다마켓이 처음이신가요? <a href="/signup">회원가입</a></span>
     </main>
+
+    <!-- Modal, mission 3 -->
     <div id="overlay" class="modal-hidden">
       <div id="modal">
         <div class="modal-content">

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -53,6 +53,7 @@
     />
 
     <!-- Google tag (gtag.js) -->
+    <script src="/env.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-WC2LGS3PNS"
@@ -64,9 +65,11 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-WC2LGS3PNS');
+      gtag('config', window.env.GA_TAG_ID);
     </script>
+
     <title>이용약관</title>
+
     <link rel="icon" href="/img/favicon.svg" />
     <link rel="stylesheet" href="/style/main.css" />
     <link

--- a/signup/index.html
+++ b/signup/index.html
@@ -53,6 +53,7 @@
     />
 
     <!-- Google tag (gtag.js) -->
+    <script src="/env.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-WC2LGS3PNS"
@@ -64,9 +65,8 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-WC2LGS3PNS');
+      gtag('config', window.env.GA_TAG_ID);
     </script>
-
     <title>회원가입</title>
     <link rel="icon" href="/img/favicon.svg" />
     <link rel="stylesheet" href="/style/auth.css" />
@@ -152,6 +152,8 @@
       </div>
       <span>이미 회원이신가요? <a href="/login/">로그인</a></span>
     </main>
+
+    <!-- Modal, mission 3 -->
     <div id="overlay" class="modal-hidden">
       <div id="modal">
         <div class="modal-content">

--- a/style/auth.css
+++ b/style/auth.css
@@ -198,13 +198,13 @@ form button {
   display: none;
 }
 
-@media only screen and (min-width: 768px) and (max-width: 1199px) {
+@media only screen and (min-width: 744px) and (max-width: 1199px) {
   .non-sticky-header {
     margin: 48px 0 40px;
   }
 }
 
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 743px) {
   .non-sticky-header {
     margin: 24px 0;
   }

--- a/style/main.css
+++ b/style/main.css
@@ -167,22 +167,21 @@ nav ul a {
 .card {
   display: flex;
   align-items: center;
+  flex-direction: row;
   gap: 64px;
   flex-wrap: wrap;
   padding: 138px 0;
 }
 
 .card img {
-  max-width: 588px;
-  width: 100%;
+  width: 588px;
   height: auto;
 }
 
 .card-texts {
   display: flex;
   flex-direction: column;
-  max-width: 300px;
-  min-width: 300px;
+  max-width: 303px;
   width: 100%;
 }
 
@@ -298,7 +297,7 @@ footer .icons {
   }
 }
 
-@media only screen and (min-width: 768px) and (max-width: 1199px) {
+@media only screen and (min-width: 744px) and (max-width: 1199px) {
   #wrapper {
     padding: 0 var(--24px) var(--40px);
   }
@@ -364,13 +363,15 @@ footer .icons {
   }
 }
 
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 743px) {
   .desktop {
     display: none;
   }
 
   #wrapper {
     padding: 0 1rem 2rem;
+    margin: 0;
+    width: 100%;
   }
 
   .mobile {
@@ -424,12 +425,13 @@ footer .icons {
   }
 
   .card {
-    margin: 0 auto;
+    /* margin: 0 auto; */
     gap: 1rem;
     padding: 2rem 0;
     flex-wrap: nowrap;
     flex-direction: column;
     align-items: flex-start;
+    width: 100%;
   }
 
   .search.card {
@@ -443,7 +445,7 @@ footer .icons {
 
   .card img {
     min-width: 343px;
-    max-width: fit-content;
+    width: 100%;
   }
 
   .card-texts span,
@@ -468,7 +470,10 @@ footer .icons {
     margin-right: 1rem;
     gap: 24px;
   }
+}
 
+/* footer order change  when it's wrapped*/
+@media only screen and (max-width: 465px) {
   .footer-container p {
     order: 3;
   }


### PR DESCRIPTION
## 요구사항

### 기본


**공통**

- [x] Github에 스프린트 미션 PR을 만들어 주세요.
로그인, 회원가입 페이지 공통

- [x] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

const USER_DATA = [
    { email: 'codeit1@codeit.com', password: "codeit101!" },
    { email: 'codeit2@codeit.com', password: "codeit202!" },
    { email: 'codeit3@codeit.com', password: "codeit303!" },
    { email: 'codeit4@codeit.com', password: "codeit404!" },
    { email: 'codeit5@codeit.com', password: "codeit505!" },
    { email: 'codeit6@codeit.com', password: "codeit606!" },
];

**로그인 페이지**

- [x] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.

**회원가입**

- [x] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

### 심화

**공통**

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.
- [x] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.
- [x] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.


**랜딩 페이지**

- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
 - PC: 1200px 이상
 - Tablet: 744px 이상 ~ 1199px 이하
 - Mobile: 375px 이상 ~ 743px 이하
 - 375px 미만 사이즈의 디자인은 고려하지 않습니다

- [x] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.
- [x] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
- [x] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.

**로그인, 회원가입 페이지 공통**

- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
- [x] 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.


## 주요 변경사항

- mission3 내용은 모든 JS파일과, singup.html login.html 파일입니다. 
- open graph meta tag.
- 구글 tag ID 환경변수로 적용. (.gitignore)
- 비밀번호는 숫자, 영문, 심볼 하나 이상을 조합해야 valid.
- 요구사항 수정으로 media query 사이즈 변경.

## 스크린샷
### open graph: Preview
---
Discord_preview
<img width="600" alt="preview_discord" src="https://github.com/user-attachments/assets/435b7b12-df56-46cc-916c-a4e1936ed758">

KakaoTalk_preview
<img width="400" alt="preview_kakaotalk" src="https://github.com/user-attachments/assets/151599a5-a5cf-4145-9677-9c05858f88a4">

imessage_preview
<img width="400" alt="preview_message" src="https://github.com/user-attachments/assets/5a589015-57cc-4586-b62f-a83afa7397b5">

Twitter_preview
<img width="400" alt="preview_twitter" src="https://github.com/user-attachments/assets/fd16180f-0839-4e9c-a3c2-86dbe446247d">

<br>

### Validation
---

**Invalid login format**

<img width="600" alt="Invalid login format" src="https://github.com/user-attachments/assets/96ba30b1-6496-4c35-bd17-b665b3841c74">

**login failed**

<img width="600" alt="login failed" src="https://github.com/user-attachments/assets/e1c9b25e-b439-4d34-b38b-a65be1ada30f">

**Invalid signup format**

<img width="600" alt="invalid signup format" src="https://github.com/user-attachments/assets/ee58042e-3032-43ce-9ee6-d97d107cc47e">

**Confirm password failed**

<img width="600" alt="confirmPw failed" src="https://github.com/user-attachments/assets/32354129-4a17-425b-975a-50b9895edc02">

**Existed email**

<img width="600" alt="already existed email" src="https://github.com/user-attachments/assets/22cdf792-5fb8-4037-9144-3060a9b37187">

**Modal for successful signup, which redirects to login page**

<img width="600" alt="successful_signup" src="https://github.com/user-attachments/assets/84ce542e-e02c-41a4-9290-aaa190481b62">




## 멘토에게

-웹사이트: https://amberim-panda-market.netlify.app/
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
