### PR TITLE
[박시연] sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="일상에서 모든 물건을 거래해보세요">
+  <meta property="og:title" content="판다마켓">
+  <meta property="og:url" content="https://fanda-market.netlify.app/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="main_page.png">
   <title>판다마켓</title>
   <link rel="stylesheet" href="reset.css">
   <link rel="stylesheet" href="style.css">

--- a/items.html
+++ b/items.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="일상에서 모든 물건을 거래해보세요">
+  <meta property="og:title" content="판다마켓">
+  <meta property="og:url" content="https://fanda-market.netlify.app/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="main_page.png">
+  <title>판다마켓</title>
+  <link rel="stylesheet" href="reset.css">
+  <link rel="stylesheet" href="style.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-E7F0PR29DX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-E7F0PR29DX');
+  </script>
+</head>
+<body>
+  <header>
+    <div class="gnb">
+      <nav>
+        <a href="/" class="logo"><img src=images/logo.png alt="판다마켓 로고"></a>
+        <a href="/" class="logo_m"><img src=images/logo_m.png alt="판다마켓 로고"></a>
+        <p class="board"><a href="/">자유게시판</a></p>
+        <p class="board"><a href="/">중고마켓</a></p>
+      </nav>
+      <p class="login"><a href="/login.html">로그인</a></p>
+    </div>
+  </header>
+  <footer>
+    <div class="show">
+      <div class="copy">
+        <p>&copy;codeit - 2024</p>
+      </div>
+      <ul class="link">
+        <li><a href="/privacy.html">Privacy Policy</a></li>
+        <li><a href="/faq.html">FAQ</a></li>
+      </ul>
+      <ul class="icon">
+        <li><a href="https://www.facebook.com" target="_blank"><img src="images/icon-facebook.png" alt="페이스북 바로가기"></a></li>
+        <li><a href="https://twitter.com" target="_blank"><img src="images/icon-twitter.png" alt="트위터 바로가기"></a></li>
+        <li><a href="https://www.youtube.com" target="_blank"><img src="images/icon-youtube.png" alt="유튜브 바로가기"></a></li>
+        <li><a href="https://www.instagram.com" target="_blank"><img src="images/icon-instagram.png" alt="인스타그램 바로가기"></a></li>
+      </ul>
+    </div>
+    <div class="none">
+      <div class="top">
+        <ul class="link">
+          <li><a href="/privacy.html">Privacy Policy</a></li>
+          <li><a href="/faq.html">FAQ</a></li>
+        </ul>
+        <ul class="icon">
+          <li><a href="https://www.facebook.com" target="_blank"><img src="images/icon-facebook.png" alt="페이스북 바로가기"></a></li>
+          <li><a href="https://twitter.com" target="_blank"><img src="images/icon-twitter.png" alt="트위터 바로가기"></a></li>
+          <li><a href="https://www.youtube.com" target="_blank"><img src="images/icon-youtube.png" alt="유튜브 바로가기"></a></li>
+          <li><a href="https://www.instagram.com" target="_blank"><img src="images/icon-instagram.png" alt="인스타그램 바로가기"></a></li>
+        </ul>
+      </div>
+      <div class="copy">
+        <p>&copy;codeit - 2024</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/login.css
+++ b/login.css
@@ -6,6 +6,7 @@
   --blue2-color: #3182F6;
   --white-color: #ffffff;
   --background-color: #E6F2FF;
+  --red-color: #f74747;
 }
 
 @font-face {
@@ -36,6 +37,7 @@ header {
 .email, .password {
   display: flex;
   flex-direction: column;
+  margin: 0 0 24px;
 }
 
 label {
@@ -51,7 +53,6 @@ input {
   color: var(--gray400-color);
   font-size: 16px;
   height: 56px;
-  margin: 0 0 24px;
   padding: 16px 24px;
 }
 
@@ -59,16 +60,32 @@ input:focus {
   border: 1px solid var(--blue-color);
 }
 
-button {
+.error {
+  border: 1px solid var(--red-color);
+}
+
+.email-error-message, .password-error-message {
+  color: var(--red-color);
+  display: none;
+  font-size: 15px;
+  margin: 8px 0 0 16px;
+}
+
+.login-button {
   background-color: var(--gray400-color);
   border: none;
   border-radius: 40px;
   color: var(--white-color);
-  cursor: pointer;
+  cursor: not-allowed;
   font-size: 20px;
   font-weight: 600;
   height: 56px;
   width: 640px;
+}
+
+.login-button:not(.disabled) {
+  background-color: var(--blue-color);
+  cursor: pointer;
 }
 
 .password {
@@ -77,7 +94,7 @@ button {
 
 .password-image {
   position: absolute;
-  bottom: 42px;
+  top: 52px;
   right: 24px;
   width: 24px;
 }
@@ -115,4 +132,107 @@ button {
 .join-us {
   color: var(--blue2-color);
   text-decoration: underline;
+}
+
+.bg {
+  background-color: rgba(0, 0, 0, 0.7);
+  display: none;
+  height: 100vh;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.modal {
+  background-color: var(--white-color);
+  border-radius: 8px;
+  height: 250px;
+  width: 540px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.alert {
+  font-size: 16px;
+  font-weight: 500;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.modal button {
+  background-color: var(--blue-color);
+  border: none;
+  border-radius: 8px;
+  color: var(--white-color);
+  cursor: pointer;
+  height: 48px;
+  width: 120px;
+  position: absolute;
+  bottom: 28px;
+  right: 28px;
+}
+
+@media (min-width: 744px) and (max-width: 1199px) {
+  .logo img {
+    padding: 48px 0 40px;
+  }
+}
+
+@media (min-width: 375px) and (max-width: 743px) {
+  header {
+    width: 344px;
+  }
+
+  .logo img {
+    padding: 24px 0;
+    width: 198px;
+  }
+
+  .wrap {
+    max-width: 400px;
+    min-width: 343px;
+  }
+
+  label {
+    font-size: 14px;
+    margin: 0 0 8px;
+  }
+
+  input {
+    margin: 0 0 16px;
+  }
+
+  .login-button {
+    max-width: 400px;
+    min-width: 343px;
+  }
+
+  .password-image {
+    top: 40px;
+  }
+
+  .sns {
+    padding: 16px 24px 16px 0;
+  }
+
+  .modal {
+    height: 220px;
+    width: 327px;
+  }
+
+  .alert {
+    top: 45%;
+    text-align: center;
+    width: 100%;
+  }
+
+  .modal button {
+    bottom: 23px;
+    right: 103px;
+  }
 }

--- a/login.html
+++ b/login.html
@@ -22,17 +22,19 @@
   </header>
   <main>
     <div class="wrap">
-      <form>
+      <form class="login-form">
         <div class="email">
           <label for="email">이메일</label>
           <input id="email" name="email" type="email" placeholder="이메일을 입력해주세요">
+          <p class="email-error-message">잘못된 이메일 형식입니다.</p>
         </div>
         <div class="password">
           <label for="password">비밀번호</label>
           <input id="password" name="password" type="password" placeholder="비밀번호를 입력해주세요">
           <img src="images/password.png" class="password-image">
+          <p class="password-error-message">비밀번호를 8자 이상 입력해주세요</p>
         </div>
-        <button>로그인</button>
+        <button class="login-button">로그인</button>
       </form>
       <div class="sns-login">
         <p>간편 로그인하기</p>
@@ -42,9 +44,16 @@
         </ul>
       </div>
       <div class="join">
-        <p>판다마켓이 처음이신가요? <span class="join-us"><a href="/signup">회원가입</a></span></p>
+        <p>판다마켓이 처음이신가요? <span class="join-us"><a href="/signup.html">회원가입</a></span></p>
       </div>
     </div>
   </main>
+  <div class="bg">
+    <div class="modal">
+      <p class="alert">비밀번호가 일치하지 않습니다.</p>
+      <button class="modal-button">확인</button>
+    </div>
+  </div>
+  <script src="main.js "></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -54,6 +54,6 @@
       <button class="modal-button">확인</button>
     </div>
   </div>
-  <script src="main.js "></script>
+  <script src="login.js "></script>
 </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,95 @@
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: "codeit101!" },
+  { email: 'codeit2@codeit.com', password: "codeit202!" },
+  { email: 'codeit3@codeit.com', password: "codeit303!" },
+  { email: 'codeit4@codeit.com', password: "codeit404!" },
+  { email: 'codeit5@codeit.com', password: "codeit505!" },
+  { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
+const emailInput = document.getElementById('email');
+const emailError = document.querySelector('.email-error-message');
+const passwordInput = document.getElementById('password');
+const passwordError = document.querySelector('.password-error-message');
+const loginButton = document.querySelector('.login-button');
+const loginForm = document.querySelector('.login-form');
+const bg = document.querySelector('.bg');
+const modalButton = document.querySelector('.modal-button');
+
+function isValidEmail(email) {
+  const at = email.indexOf('@');
+  if (at < 1) {
+    return false;
+  }
+
+  const dot = email.indexOf('.', at);
+  if (dot <= at + 1) {
+    return false;
+  }
+
+  if (dot === email.length - 1) {
+    return false;
+  }
+
+  return true;
+}
+
+function updateButtonState() {
+  const isEmailValid = emailInput.value.trim() !== '' && isValidEmail(emailInput.value.trim());
+  const isPasswordValid = passwordInput.value.trim() !== '' && passwordInput.value.trim().length >= 8;
+
+  loginButton.disabled = !(isEmailValid && isPasswordValid);
+  loginButton.classList.toggle('disabled', loginButton.disabled);
+}
+
+function validateEmail() {
+  if (emailInput.value.trim() === '') {
+    emailInput.classList.add('error');
+    emailError.style.display = 'block';
+  } else if (!isValidEmail(emailInput.value.trim())) {
+    emailInput.classList.add('error');
+    emailError.style.display = 'block';
+  } else {
+    emailInput.classList.remove('error');
+    emailError.style.display = 'none';
+  }
+  updateButtonState();
+}
+
+function validatePassword() {
+  if (passwordInput.value.trim() === '') {
+    passwordInput.classList.add('error');
+    passwordError.style.display = 'block';
+  } else if (passwordInput.value.trim().length < 8) {
+    passwordInput.classList.add('error');
+    passwordError.style.display = 'block';
+  } else {
+    passwordInput.classList.remove('error');
+    passwordError.style.display = 'none';
+  }
+  updateButtonState();
+}
+
+emailInput.addEventListener('focusout', validateEmail);
+passwordInput.addEventListener('focusout', validatePassword);
+modalButton.addEventListener('click', function() {
+  bg.style.display = 'none';
+});
+
+loginForm.addEventListener('submit', function(event) {
+  event.preventDefault();
+  const email = emailInput.value.trim();
+  const password = passwordInput.value.trim();
+  const user = USER_DATA.find(user => user.email === email);
+  if (user) {
+    if (user.password === password) {
+      window.location.href = '/items.html';
+    } else {
+      bg.style.display = 'block';
+    }
+  } else {
+    bg.style.display = 'block';
+  }
+});
+
+updateButtonState();

--- a/main.js
+++ b/main.js
@@ -1,0 +1,142 @@
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: "codeit101!" },
+  { email: 'codeit2@codeit.com', password: "codeit202!" },
+  { email: 'codeit3@codeit.com', password: "codeit303!" },
+  { email: 'codeit4@codeit.com', password: "codeit404!" },
+  { email: 'codeit5@codeit.com', password: "codeit505!" },
+  { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
+const emailInput = document.getElementById('email');
+const emailError = document.querySelector('.email-error-message');
+const passwordInput = document.getElementById('password');
+const passwordError = document.querySelector('.password-error-message');
+const passwordRepeatInput = document.getElementById('password-repeat');
+const passwordRepeatError = document.querySelector('.password-repeat-error-message');
+const loginButton = document.querySelector('.login-button');
+const signupButton = document.querySelector('.signup-button');
+const loginForm = document.querySelector('.login-form');
+const signupForm = document.querySelector('.signup-form');
+const bg = document.querySelector('.bg');
+const modalButton = document.querySelector('.modal-button');
+
+function isValidEmail(email) {
+  const at = email.indexOf('@');
+  if (at < 1) {
+    return false;
+  }
+
+  const dot = email.indexOf('.', at);
+  if (dot <= at + 1) {
+    return false;
+  }
+
+  if (dot === email.length - 1) {
+    return false;
+  }
+
+  return true;
+}
+
+function updateButtonState() {
+  const isEmailValid = emailInput.value.trim() !== '' && isValidEmail(emailInput.value.trim());
+  const isPasswordValid = passwordInput.value.trim() !== '' && passwordInput.value.trim().length >= 8;
+  const isPasswordRepeatValid = passwordRepeatInput ? (passwordRepeatInput.value.trim() !== '' && passwordRepeatInput.value.trim() === passwordInput.value.trim()) : true;
+
+  if (loginButton) {
+    loginButton.disabled = !(isEmailValid && isPasswordValid);
+    loginButton.classList.toggle('disabled', loginButton.disabled);
+  }
+
+  if (signupButton) {
+    signupButton.disabled = !(isEmailValid && isPasswordValid && isPasswordRepeatValid);
+    signupButton.classList.toggle('disabled', signupButton.disabled);
+  }
+}
+
+function validateEmail() {
+  if (emailInput.value.trim() === '') {
+    emailInput.classList.add('error');
+    emailError.style.display = 'block';
+  } else if (!isValidEmail(emailInput.value.trim())) {
+    emailInput.classList.add('error');
+    emailError.style.display = 'block';
+  } else {
+    emailInput.classList.remove('error');
+    emailError.style.display = 'none';
+  }
+  updateButtonState();
+}
+
+function validatePassword() {
+  if (passwordInput.value.trim() === '') {
+    passwordInput.classList.add('error');
+    passwordError.style.display = 'block';
+  } else if (passwordInput.value.trim().length < 8) {
+    passwordInput.classList.add('error');
+    passwordError.style.display = 'block';
+  } else {
+    passwordInput.classList.remove('error');
+    passwordError.style.display = 'none';
+  }
+  updateButtonState();
+}
+
+function validatePasswordRepeat() {
+  if (passwordRepeatInput) {
+    if (passwordRepeatInput.value.trim() === '') {
+      passwordRepeatInput.classList.add('error');
+      passwordRepeatError.style.display = 'block';
+    } else if (passwordRepeatInput.value.trim() !== passwordInput.value.trim()) {
+      passwordRepeatInput.classList.add('error');
+      passwordRepeatError.style.display = 'block';
+    } else {
+      passwordRepeatInput.classList.remove('error');
+      passwordRepeatError.style.display = 'none';
+    }
+  }
+  updateButtonState();
+}
+
+emailInput.addEventListener('focusout', validateEmail);
+passwordInput.addEventListener('focusout', validatePassword);
+if (passwordRepeatInput) {
+  passwordRepeatInput.addEventListener('focusout', validatePasswordRepeat);
+}
+modalButton.addEventListener('click', function() {
+  bg.style.display = 'none';
+});
+
+if (loginForm) {
+  loginForm.addEventListener('submit', function(event) {
+    event.preventDefault();
+    const email = emailInput.value.trim();
+    const password = passwordInput.value.trim();
+    const user = USER_DATA.find(user => user.email === email);
+    if (user) {
+      if (user.password === password) {
+        window.location.href = '/items.html';
+      } else {
+        bg.style.display = 'block';
+      }
+    } else {
+      bg.style.display = 'block';
+    }
+  });
+}
+
+if (signupForm) {
+  signupForm.addEventListener('submit', function(event) {
+    event.preventDefault();
+    const email = emailInput.value.trim();
+    const user = USER_DATA.find(user => user.email === email);
+    if (user) {
+      bg.style.display = 'block';
+    } else {
+      USER_DATA.push({ email, password: passwordInput.value.trim() });
+      window.location.href = '/login.html';
+    }
+  });
+}
+
+updateButtonState();

--- a/signup.css
+++ b/signup.css
@@ -5,6 +5,7 @@
   --blue-color: #3692ff;
   --blue2-color: #3182F6;
   --white-color: #ffffff;
+  --red-color: #f74747;
   --background-color: #E6F2FF;
 }
 
@@ -36,6 +37,7 @@ header {
 .email, .nickname, .password, .password-repeat {
   display: flex;
   flex-direction: column;
+  margin: 0 0 24px;
 }
 
 label {
@@ -51,7 +53,6 @@ input {
   color: var(--gray400-color);
   font-size: 16px;
   height: 56px;
-  margin: 0 0 24px;
   padding: 16px 24px;
 }
 
@@ -59,16 +60,32 @@ input:focus {
   border: 1px solid var(--blue-color);
 }
 
-button {
+.error {
+  border: 1px solid var(--red-color);
+}
+
+.email-error-message, .password-error-message, .password-repeat-error-message {
+  color: var(--red-color);
+  display: none;
+  font-size: 15px;
+  margin: 8px 0 0 16px;
+}
+
+.signup-button {
   background-color: var(--gray400-color);
   border: none;
   border-radius: 40px;
   color: var(--white-color);
-  cursor: pointer;
+  cursor: not-allowed;
   font-size: 20px;
   font-weight: 600;
   height: 56px;
   width: 640px;
+}
+
+.signup-button:not(.disabled) {
+  background-color: var(--blue-color);
+  cursor: pointer;
 }
 
 .password, .password-repeat {
@@ -77,7 +94,7 @@ button {
 
 .password-image {
   position: absolute;
-  bottom: 42px;
+  top: 52px;
   right: 24px;
   width: 24px;
 }
@@ -115,4 +132,105 @@ button {
 .login-us {
   color: var(--blue2-color);
   text-decoration: underline;
+}
+
+.bg {
+  background-color: rgba(0, 0, 0, 0.7);
+  display: none;
+  height: 100vh;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.modal {
+  background-color: var(--white-color);
+  border-radius: 8px;
+  height: 250px;
+  width: 540px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.alert {
+  font-size: 16px;
+  font-weight: 500;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.modal button {
+  background-color: var(--blue-color);
+  border: none;
+  border-radius: 8px;
+  color: var(--white-color);
+  cursor: pointer;
+  height: 48px;
+  width: 120px;
+  position: absolute;
+  bottom: 28px;
+  right: 28px;
+}
+
+@media (min-width: 744px) and (max-width: 1199px) {
+  .logo img {
+    padding: 48px 0 40px;
+  }
+}
+
+@media (min-width: 375px) and (max-width: 743px) {
+  header {
+    width: 344px;
+  }
+
+  .logo img {
+    padding: 24px 0;
+    width: 198px;
+  }
+
+  .wrap {
+    max-width: 400px;
+    min-width: 343px;
+  }
+
+  label {
+    font-size: 14px;
+    margin: 0 0 8px;
+  }
+
+  input {
+    margin: 0 0 16px;
+  }
+
+  .signup-button {
+    max-width: 400px;
+    min-width: 343px;
+  }
+
+  .password-image {
+    top: 40px;
+  }
+
+  .sns {
+    padding: 16px 24px 16px 0;
+  }
+
+  .modal {
+    height: 220px;
+    width: 327px;
+  }
+
+  .alert {
+    top: 45%;
+  }
+
+  .modal button {
+    bottom: 23px;
+    right: 103px;
+  }
 }

--- a/signup.html
+++ b/signup.html
@@ -22,10 +22,11 @@
   </header>
   <main>
     <div class="wrap">
-      <form>
+      <form class="signup-form">
         <div class="email">
           <label for="email">이메일</label>
           <input id="email" name="email" type="email" placeholder="이메일을 입력해주세요">
+          <p class="email-error-message">잘못된 이메일 형식입니다.</p>
         </div>
         <div class="nickname">
           <label for="nickname">닉네임</label>
@@ -35,13 +36,15 @@
           <label for="password">비밀번호</label>
           <input id="password" name="password" type="password" placeholder="비밀번호를 입력해주세요">
           <img src="images/password.png" class="password-image">
+          <p class="password-error-message">비밀번호를 8자 이상 입력해주세요</p>
         </div>
         <div class="password-repeat">
           <label for="password-repeat">비밀번호 확인</label>
           <input id="password-repeat" name="password-repeat" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요">
           <img src="images/password.png" class="password-image">
+          <p class="password-repeat-error-message">비밀번호가 일치하지 않습니다.</p>
         </div>
-        <button>회원가입</button>
+        <button class="signup-button">회원가입</button>
       </form>
       <div class="sns-login">
         <p>간편 로그인하기</p>
@@ -51,9 +54,16 @@
         </ul>
       </div>
       <div class="login">
-        <p>이미 회원이신가요? <span class="login-us"><a href="/login">로그인</a></span></p>
+        <p>이미 회원이신가요? <span class="login-us"><a href="/login.html">로그인</a></span></p>
       </div>
     </div>
   </main>
+  <div class="bg">
+    <div class="modal">
+      <p class="alert">사용 중인 이메일입니다.</p>
+      <button class="modal-button">확인</button>
+    </div>
+  </div>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -64,6 +64,6 @@
       <button class="modal-button">확인</button>
     </div>
   </div>
-  <script src="main.js"></script>
+  <script src="signup.js"></script>
 </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -12,10 +12,8 @@ const emailError = document.querySelector('.email-error-message');
 const passwordInput = document.getElementById('password');
 const passwordError = document.querySelector('.password-error-message');
 const passwordRepeatInput = document.getElementById('password-repeat');
-const passwordRepeatError = document.querySelector('.password-repeat-error-message');
-const loginButton = document.querySelector('.login-button');
-const signupButton = document.querySelector('.signup-button');
-const loginForm = document.querySelector('.login-form');
+const passwordRepeatError = document.querySelector('.password-repeat-error-message')
+const signupButton = document.querySelector('.signup-button')
 const signupForm = document.querySelector('.signup-form');
 const bg = document.querySelector('.bg');
 const modalButton = document.querySelector('.modal-button');
@@ -43,15 +41,8 @@ function updateButtonState() {
   const isPasswordValid = passwordInput.value.trim() !== '' && passwordInput.value.trim().length >= 8;
   const isPasswordRepeatValid = passwordRepeatInput ? (passwordRepeatInput.value.trim() !== '' && passwordRepeatInput.value.trim() === passwordInput.value.trim()) : true;
 
-  if (loginButton) {
-    loginButton.disabled = !(isEmailValid && isPasswordValid);
-    loginButton.classList.toggle('disabled', loginButton.disabled);
-  }
-
-  if (signupButton) {
-    signupButton.disabled = !(isEmailValid && isPasswordValid && isPasswordRepeatValid);
-    signupButton.classList.toggle('disabled', signupButton.disabled);
-  }
+  signupButton.disabled = !(isEmailValid && isPasswordValid && isPasswordRepeatValid);
+  signupButton.classList.toggle('disabled', signupButton.disabled);
 }
 
 function validateEmail() {
@@ -100,43 +91,22 @@ function validatePasswordRepeat() {
 
 emailInput.addEventListener('focusout', validateEmail);
 passwordInput.addEventListener('focusout', validatePassword);
-if (passwordRepeatInput) {
-  passwordRepeatInput.addEventListener('focusout', validatePasswordRepeat);
-}
+passwordRepeatInput.addEventListener('focusout', validatePasswordRepeat);
 modalButton.addEventListener('click', function() {
   bg.style.display = 'none';
 });
 
-if (loginForm) {
-  loginForm.addEventListener('submit', function(event) {
-    event.preventDefault();
-    const email = emailInput.value.trim();
-    const password = passwordInput.value.trim();
-    const user = USER_DATA.find(user => user.email === email);
-    if (user) {
-      if (user.password === password) {
-        window.location.href = '/items.html';
-      } else {
-        bg.style.display = 'block';
-      }
-    } else {
-      bg.style.display = 'block';
-    }
-  });
-}
 
-if (signupForm) {
-  signupForm.addEventListener('submit', function(event) {
-    event.preventDefault();
-    const email = emailInput.value.trim();
-    const user = USER_DATA.find(user => user.email === email);
-    if (user) {
-      bg.style.display = 'block';
-    } else {
-      USER_DATA.push({ email, password: passwordInput.value.trim() });
-      window.location.href = '/login.html';
-    }
-  });
-}
+signupForm.addEventListener('submit', function(event) {
+  event.preventDefault();
+  const email = emailInput.value.trim();
+  const user = USER_DATA.find(user => user.email === email);
+  if (user) {
+    bg.style.display = 'block';
+  } else {
+    USER_DATA.push({ email, password: passwordInput.value.trim() });
+    window.location.href = '/login.html';
+  }
+});
 
 updateButtonState();

--- a/style.css
+++ b/style.css
@@ -344,6 +344,7 @@ footer {
     line-height: 19.9px;
     padding: 0 8px 0 0;
     width: 100%;
+    white-space: nowrap;
   }
 
   .visual {

--- a/style.css
+++ b/style.css
@@ -136,7 +136,7 @@ section img  {
   padding: 0 0 12px 0;
 }
 
-.text-box .tltle {
+.text-box .title {
   font-size: 40px;
   font-weight: 700;
   line-height: 56px;


### PR DESCRIPTION
## 요구사항

### 기본

- [x] Github에 스프린트 미션 PR을 만들어 주세요.

로그인, 회원가입 페이지 공통

- [x] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

로그인 페이지

- [x] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.

회원가입

- [x] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

### 심화

공통

- [x]  페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.
- [x] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.
- [x]  주소와 이미지는 자유롭게 설정하세요.
- [x]  로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.

랜딩 페이지

- [ ] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 744px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 743px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다
- [x] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x]  Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.
- [x] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)
- [x] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.
로그인, 회원가입 페이지 공통

- [x]  Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x]  Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
- [x]  오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.

## 주요 변경사항

- 자바스크립트 기능 추가
- 반응형 디자인 적용

## 스크린샷

![image](이미지url)

## 멘토에게

- 모바일에서 [자유게시판]이 한줄로 나오지 않는데 어떻게 구현하면 좋을까요?
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
